### PR TITLE
Bugfix for lazy_split_view

### DIFF
--- a/rxx/chunk_view.h
+++ b/rxx/chunk_view.h
@@ -3,6 +3,7 @@
 
 #include "rxx/concepts.h"
 #include "rxx/details/adaptor_closure.h"
+#include "rxx/details/bind_back.h"
 #include "rxx/details/ceil_div.h"
 #include "rxx/details/const_if.h"
 #include "rxx/details/non_propagating_cache.h"
@@ -579,27 +580,14 @@ struct chunk_t : ranges::details::adaptor_non_closure<chunk_t> {
     template <typename T>
     static constexpr bool _S_has_simple_extra_args = true;
     static constexpr int _S_arity = 2;
-#elif RXX_LIBCXX
+#elif RXX_LIBCXX | RXX_MSVC_STL
     template <typename D>
     requires std::constructible_from<std::decay_t<D>, D>
     RXX_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) constexpr auto operator()(
         D&& size) const
         noexcept(std::is_nothrow_constructible_v<std::decay_t<D>, D>) {
         return __RXX ranges::details::make_pipeable(
-            [transformer = *this,
-                size = std::forward<D>(size)]<std::ranges::viewable_range V>(
-                V&& arg) mutable {
-                return transformer(std::forward<V>(arg), std::forward<D>(size));
-            });
-    }
-#elif RXX_MSVC_STL
-    template <typename D>
-    requires std::constructible_from<std::decay_t<D>, D>
-    RXX_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) constexpr auto operator()(
-        D&& size) const
-        noexcept(std::is_nothrow_constructible_v<std::decay_t<D>, D>) {
-        return std::ranges::_Range_closure<chunk_t, std::decay_t<D>>{
-            std::forward<D>(size)};
+            set_arity<2>(*this), std::forward<D>(size));
     }
 #else
 #  error "Unsupported"

--- a/rxx/details/adaptor_closure.h
+++ b/rxx/details/adaptor_closure.h
@@ -20,6 +20,16 @@ using adaptor_non_closure RXX_NODEBUG = adaptor_non_closure_type<Cpo>;
 template <typename Derived>
 using adaptor_closure RXX_NODEBUG = std::ranges::_Pipe::_Base<Derived>;
 
+template <typename F, typename... Args>
+RXX_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+constexpr auto make_pipeable(F&&, Args&&... args) noexcept(
+    std::is_nothrow_constructible_v<
+        std::ranges::_Range_closure<std::decay_t<F>, std::decay_t<Args>...>,
+        Args...>) {
+    return std::ranges::_Range_closure<std::decay_t<F>, std::decay_t<Args>...>{
+        std::forward<Args>(args)...};
+}
+
 #elif RXX_LIBCXX
 
 template <typename Cpo>
@@ -41,7 +51,6 @@ template <typename F>
 RXX_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
 constexpr auto make_pipeable(F&& func) noexcept(
     std::is_nothrow_constructible_v<std::decay_t<F>, F>) {
-
 #  if RXX_LIBCXX_AT_LEAST(20, 01, 00)
     return std::ranges::__pipeable<std::decay_t<F>>{std::forward<F>(func)};
 #  elif RXX_LIBCXX_AT_LEAST(19, 01, 00)
@@ -51,6 +60,15 @@ constexpr auto make_pipeable(F&& func) noexcept(
     return std::__range_adaptor_closure_t<std::decay_t<F>>{
         std::forward<F>(func)};
 #  endif
+}
+
+template <typename F, typename... Args>
+RXX_ATTRIBUTES(_HIDE_FROM_ABI, ALWAYS_INLINE, NODISCARD)
+constexpr auto make_pipeable(F&& func, Args&&... args) noexcept(
+    (std::is_nothrow_constructible_v<std::decay_t<F>, F> && ... &&
+        std::is_nothrow_constructible_v<std::decay_t<Args>, Args>)) {
+    return make_pipeable(
+        bind_back(std::forward<F>(func), std::forward<Args>(args)...));
 }
 
 #elif RXX_LIBSTDCXX

--- a/rxx/details/bind_back.h
+++ b/rxx/details/bind_back.h
@@ -1,0 +1,184 @@
+// Copyright 2025 Bryan Wong
+#pragma once
+
+#include "rxx/config.h"
+
+#include "rxx/details/overlappable_if.h"
+
+#include <concepts>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+RXX_DEFAULT_NAMESPACE_BEGIN
+
+namespace ranges::details {
+
+template <typename F, typename... Ts>
+class bind_back_t {
+public:
+    template <typename Func, typename... Args>
+    requires (std::constructible_from<F, Func> && ... &&
+        std::constructible_from<Ts, Args>)
+    __RXX_HIDE_FROM_ABI constexpr bind_back_t(Func&& func,
+        Args&&... args) noexcept((std::is_nothrow_constructible_v<F, Func> &&
+        ... && std::is_nothrow_constructible_v<Ts, Args>))
+        : container_{std::in_place, std::forward<Func>(func),
+              std::forward<Args>(args)...} {}
+
+    __RXX_HIDE_FROM_ABI constexpr bind_back_t(bind_back_t const&) = default;
+    __RXX_HIDE_FROM_ABI constexpr bind_back_t& operator=(
+        bind_back_t const&) = default;
+    __RXX_HIDE_FROM_ABI constexpr bind_back_t(bind_back_t&&) = default;
+    __RXX_HIDE_FROM_ABI constexpr bind_back_t& operator=(
+        bind_back_t&&) = default;
+
+    template <typename... Us>
+    requires std::regular_invocable<F const&, Us..., Ts const&...>
+    __RXX_HIDE_FROM_ABI constexpr auto operator()(Us&&... args) const& noexcept(
+        std::is_nothrow_invocable_v<F const&, Us..., Ts const&...>)
+        -> decltype(auto) {
+        return std::apply(
+            [&](Ts const&... bound) -> decltype(auto) {
+                return std::invoke(container_.data.func.data,
+                    std::forward<Us>(args)..., bound...);
+            },
+            container_.data.args);
+    }
+
+    template <typename... Us>
+    requires std::regular_invocable<F const, Us..., Ts const...>
+    __RXX_HIDE_FROM_ABI constexpr auto
+    operator()(Us&&... args) const&& noexcept(
+        std::is_nothrow_invocable_v<F const, Us..., Ts const...>)
+        -> decltype(auto) {
+        return std::apply(
+            [&](Ts const&&... bound) -> decltype(auto) {
+                return std::invoke(std::move(container_.data.func.data),
+                    std::forward<Us>(args)..., std::move(bound)...);
+            },
+            std::move(container_.data.args));
+    }
+
+    template <typename... Us>
+    requires std::regular_invocable<F&, Us..., Ts&...>
+    __RXX_HIDE_FROM_ABI constexpr auto operator()(Us&&... args) & noexcept(
+        std::is_nothrow_invocable_v<F&, Us..., Ts&...>) -> decltype(auto) {
+        return std::apply(
+            [&](Ts&... bound) -> decltype(auto) {
+                return std::invoke(container_.data.func.data,
+                    std::forward<Us>(args)..., bound...);
+            },
+            container_.data.args);
+    }
+
+    template <typename... Us>
+    requires std::regular_invocable<F, Us..., Ts...>
+    __RXX_HIDE_FROM_ABI constexpr auto operator()(Us&&... args) && noexcept(
+        std::is_nothrow_invocable_v<F, Us..., Ts...>) -> decltype(auto) {
+        return std::apply(
+            [&](Ts&&... bound) -> decltype(auto) {
+                return std::invoke(std::move(container_.data.func.data),
+                    std::forward<Us>(args)..., std::move(bound)...);
+            },
+            std::move(container_.data.args));
+    }
+
+private:
+    __RXX_HIDE_FROM_ABI static constexpr bool place_args_in_tail =
+        fits_in_tail_padding_v<F, std::tuple<Ts...>>;
+    __RXX_HIDE_FROM_ABI static constexpr bool allow_external_overlap =
+        !place_args_in_tail;
+
+    struct container {
+        template <typename Func, typename... Args>
+        requires (std::constructible_from<F, Func> && ... &&
+                     std::constructible_from<Ts, Args>)
+        __RXX_HIDE_FROM_ABI constexpr container(Func&& func,
+            Args&&... args) noexcept((std::is_nothrow_constructible_v<F,
+                                          Func> &&
+            ... && std::is_nothrow_constructible_v<Ts, Args>))
+            : func{std::in_place, std::forward<Func>(func)}
+            , args{std::forward<Args>(args)...} {}
+        __RXX_HIDE_FROM_ABI constexpr container(container const&) = default;
+        __RXX_HIDE_FROM_ABI constexpr container& operator=(
+            container const&) = default;
+        __RXX_HIDE_FROM_ABI constexpr container(container&&) = default;
+        __RXX_HIDE_FROM_ABI constexpr container& operator=(
+            container&&) = default;
+
+        RXX_ATTRIBUTE(NO_UNIQUE_ADDRESS)
+        overlappable_if<place_args_in_tail, F> func;
+        RXX_ATTRIBUTE(NO_UNIQUE_ADDRESS) std::tuple<Ts...> args;
+    };
+
+    RXX_ATTRIBUTE(NO_UNIQUE_ADDRESS)
+    overlappable_if<allow_external_overlap, container> container_;
+};
+
+template <typename F, typename... Args>
+requires (std::constructible_from<std::decay_t<F>, F> && ... &&
+    std::constructible_from<std::decay_t<Args>, Args>)
+RXX_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) constexpr auto bind_back(F&& func,
+    Args&&... args) noexcept((std::is_nothrow_constructible_v<std::decay_t<F>,
+                                  F> &&
+    ... && std::is_nothrow_constructible_v<std::decay_t<Args>, Args>)) {
+    return bind_back_t<std::decay_t<F>, std::decay_t<Args>...>{
+        std::forward<F>(func), std::forward<Args>(args)...};
+}
+
+template <typename F, size_t N>
+class set_arity_t {
+public:
+    __RXX_HIDE_FROM_ABI constexpr set_arity_t() noexcept(
+        std::is_nothrow_default_constructible_v<F>) = default;
+
+    template <typename Func>
+    requires std::constructible_from<F, Func>
+    __RXX_HIDE_FROM_ABI constexpr set_arity_t(Func&& func) noexcept(
+        std::is_nothrow_constructible_v<F, Func>)
+        : func_{std::forward<Func>(func)} {}
+
+    template <typename... Us>
+    requires (sizeof...(Us) == N) && std::regular_invocable<F const&, Us...>
+    __RXX_HIDE_FROM_ABI constexpr auto operator()(Us&&... args) const& noexcept(
+        std::is_nothrow_invocable_v<F const&, Us...>) -> decltype(auto) {
+        return std::invoke(func_, std::forward<Us>(args)...);
+    }
+
+    template <typename... Us>
+    requires (sizeof...(Us) == N) && std::regular_invocable<F const, Us...>
+    __RXX_HIDE_FROM_ABI constexpr auto
+    operator()(Us&&... args) const&& noexcept(
+        std::is_nothrow_invocable_v<F const, Us...>) -> decltype(auto) {
+        return std::invoke(std::move(func_), std::forward<Us>(args)...);
+    }
+
+    template <typename... Us>
+    requires (sizeof...(Us) == N) && std::regular_invocable<F&, Us...>
+    __RXX_HIDE_FROM_ABI constexpr auto operator()(Us&&... args) & noexcept(
+        std::is_nothrow_invocable_v<F&, Us...>) -> decltype(auto) {
+        return std::invoke(func_, std::forward<Us>(args)...);
+    }
+
+    template <typename... Us>
+    requires (sizeof...(Us) == N) && std::regular_invocable<F, Us...>
+    __RXX_HIDE_FROM_ABI constexpr auto operator()(Us&&... args) && noexcept(
+        std::is_nothrow_invocable_v<F, Us...>) -> decltype(auto) {
+        return std::invoke(std::move(func_), std::forward<Us>(args)...);
+    }
+
+private:
+    RXX_ATTRIBUTE(NO_UNIQUE_ADDRESS) F func_;
+};
+
+template <size_t Min, typename F>
+requires std::constructible_from<std::decay_t<F>, F>
+RXX_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) constexpr auto set_arity(
+    F&& func) noexcept(std::is_nothrow_constructible_v<std::decay_t<F>, F>) {
+    return set_arity_t<std::decay_t<F>, Min>{std::forward<F>(func)};
+}
+
+} // namespace ranges::details
+
+RXX_DEFAULT_NAMESPACE_END

--- a/rxx/drop_view.h
+++ b/rxx/drop_view.h
@@ -1,6 +1,7 @@
 // Copyright 2025 Bryan Wong
 #pragma once
 
+#include "rxx/details/bind_back.h"
 #include "rxx/details/view_traits.h"
 
 #include <functional>
@@ -41,26 +42,14 @@ struct drop_t : ranges::details::adaptor_non_closure<drop_t> {
         std::ranges::__detail::__is_integer_like<_Tp>;
 
     static constexpr int _S_arity = 2;
-#elif RXX_LIBCXX
+#elif RXX_LIBCXX | RXX_MSVC_STL
     template <typename N>
     requires std::constructible_from<std::decay_t<N>, N>
     RXX_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) constexpr auto operator()(
         N&& num) const
         noexcept(std::is_nothrow_constructible_v<std::decay_t<N>, N>) {
         return __RXX ranges::details::make_pipeable(
-            [droper = *this, num = std::forward<N>(num)]<typename V>(
-                V&& arg) mutable {
-                return droper(std::forward<V>(arg), std::forward<N>(num));
-            });
-    }
-#elif RXX_MSVC_STL
-    template <typename N>
-    requires std::constructible_from<std::decay_t<N>, N>
-    RXX_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) constexpr auto operator()(
-        N&& num) const
-        noexcept(std::is_nothrow_constructible_v<std::decay_t<N>, N>) {
-        return std::ranges::_Range_closure<take_t, std::decay_t<N>>{
-            std::forward<N>(num)};
+            set_arity<2>(*this), std::forward<N>(num));
     }
 #else
 #  error "Unsupported"

--- a/rxx/slide_view.h
+++ b/rxx/slide_view.h
@@ -3,6 +3,7 @@
 
 #include "rxx/concepts.h"
 #include "rxx/details/adaptor_closure.h"
+#include "rxx/details/bind_back.h"
 #include "rxx/details/cached_position.h"
 #include "rxx/details/const_if.h"
 #include "rxx/details/simple_view.h"
@@ -427,24 +428,13 @@ struct slide_t : ranges::details::adaptor_non_closure<slide_t> {
     using ranges::details::adaptor_non_closure<slide_t>::operator();
     static constexpr int _S_arity = 2;
     static constexpr bool _S_has_simple_extra_args = true;
-#elif RXX_LIBCXX
+#elif RXX_LIBCXX | RXX_MSVC_STL
     template <typename D>
     requires std::constructible_from<std::decay_t<D>, D>
     RXX_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) constexpr auto operator()(
         D num) const
         noexcept(std::is_nothrow_constructible_v<std::decay_t<D>, D>) {
-        return __RXX ranges::details::make_pipeable(
-            [slider = *this, num = num]<typename V>(
-                V&& arg) mutable { return slider(std::forward<V>(arg), num); });
-    }
-#elif RXX_MSVC_STL
-    template <typename D>
-    requires std::constructible_from<std::decay_t<D>, D>
-    RXX_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) constexpr auto operator()(
-        D num) const
-        noexcept(std::is_nothrow_constructible_v<std::decay_t<D>, D>) {
-        return std::ranges::_Range_closure<slide_t, std::decay_t<D>>{
-            std::forward<D>(delimiter)};
+        return __RXX ranges::details::make_pipeable(set_arity<2>(*this), num);
     }
 #else
 #  error "Unsupported"

--- a/rxx/take_view.h
+++ b/rxx/take_view.h
@@ -1,6 +1,7 @@
 // Copyright 2025 Bryan Wong
 #pragma once
 
+#include "rxx/details/bind_back.h"
 #include "rxx/details/view_traits.h"
 
 #include <functional>
@@ -39,26 +40,14 @@ struct take_t : ranges::details::adaptor_non_closure<take_t> {
     static constexpr bool _S_has_simple_extra_args =
         std::ranges::__detail::__is_integer_like<T>;
     static constexpr int _S_arity = 2;
-#elif RXX_LIBCXX
+#elif RXX_LIBCXX | RXX_MSVC_STL
     template <typename N>
     requires std::constructible_from<std::decay_t<N>, N>
     RXX_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) constexpr auto operator()(
         N&& num) const
         noexcept(std::is_nothrow_constructible_v<std::decay_t<N>, N>) {
         return __RXX ranges::details::make_pipeable(
-            [taker = *this, num = std::forward<N>(num)]<typename V>(
-                V&& arg) mutable {
-                return taker(std::forward<V>(arg), std::forward<N>(num));
-            });
-    }
-#elif RXX_MSVC_STL
-    template <typename N>
-    requires std::constructible_from<std::decay_t<N>, N>
-    RXX_ATTRIBUTES(_HIDE_FROM_ABI, NODISCARD) constexpr auto operator()(
-        N&& num) const
-        noexcept(std::is_nothrow_constructible_v<std::decay_t<N>, N>) {
-        return std::ranges::_Range_closure<take_t, std::decay_t<N>>{
-            std::forward<N>(num)};
+            set_arity<2>(*this), std::forward<N>(num));
     }
 #else
 #  error "Unsupported"


### PR DESCRIPTION
* Tested against GCC and LLVM test suite
* Added `bind_back` as there were issues with forwarding/lifetime
* Stadardize pipeable/closures for MSVC and clang
