### PR TITLE
Fix/concat view gcc memory

### DIFF
--- a/rxx/details/jump_table.h
+++ b/rxx/details/jump_table.h
@@ -146,9 +146,8 @@ private:
     }
 
     template <size_t I, typename F, typename... Args>
-    RXX_ATTRIBUTES(_HIDE_FROM_ABI, FLATTEN)
-    static constexpr auto impl(F&& callable, T value, Args&&... args)
-        -> decltype(auto) {
+    __RXX_HIDE_FROM_ABI static constexpr auto impl(
+        F&& callable, T value, Args&&... args) -> decltype(auto) {
 #define __RXX_JT_CASE(X)        \
     case index_to_value(I + X): \
         return case_<I + X>(    \

--- a/rxx/ranges/concat_view.h
+++ b/rxx/ranges/concat_view.h
@@ -3,7 +3,6 @@
 
 #include "rxx/config.h"
 
-#include "rxx/configuration/builtins.h"
 #include "rxx/details/concat.h"
 #include "rxx/details/packed_range_traits.h"
 #include "rxx/details/simple_view.h"


### PR DESCRIPTION
* Fix memory issue likely caused by quadratic codepaths when decrementing `concat_view`
   * Add a non-returnable type to jump-table to better deal with functions returning `void`
   * Fixed by reducing the number of code paths generated by jump_table